### PR TITLE
revert hashicorp archive version to 2.4.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "2.4.1"
+      version = "~> 2.4.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Revert HashiCorp Archive Provider Version to 2.4.0 for Consistency with dq-tf-apps